### PR TITLE
feat(PRO-339): Complete Phase 2 – Core Application Migration to Spring Boot 3

### DIFF
--- a/kitchensink-spring-boot/.gitignore
+++ b/kitchensink-spring-boot/.gitignore
@@ -1,0 +1,9 @@
+/target/
+.idea/
+*.iml
+.classpath
+.project
+.settings/
+
+# OS
+.DS_Store

--- a/kitchensink-spring-boot/pom.xml
+++ b/kitchensink-spring-boot/pom.xml
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.springframework.boot</groupId>
+    <artifactId>spring-boot-starter-parent</artifactId>
+    <version>3.3.2</version>
+    <relativePath/>
+  </parent>
+
+  <groupId>org.jboss.as.quickstarts</groupId>
+  <artifactId>kitchensink-spring-boot</artifactId>
+  <version>0.0.1-SNAPSHOT</version>
+  <name>kitchensink-spring-boot</name>
+  <description>Migrated Kitchensink Spring Boot Application</description>
+
+  <properties>
+    <java.version>21</java.version>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-web</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-validation</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-data-jpa</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.h2database</groupId>
+      <artifactId>h2</artifactId>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.projectlombok</groupId>
+      <artifactId>lombok</artifactId>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-test</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-maven-plugin</artifactId>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/kitchensink-spring-boot/src/main/java/org/jboss/as/quickstarts/kitchensink/KitchensinkApplication.java
+++ b/kitchensink-spring-boot/src/main/java/org/jboss/as/quickstarts/kitchensink/KitchensinkApplication.java
@@ -1,0 +1,11 @@
+package org.jboss.as.quickstarts.kitchensink;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class KitchensinkApplication {
+    public static void main(String[] args) {
+        SpringApplication.run(KitchensinkApplication.class, args);
+    }
+}

--- a/kitchensink-spring-boot/src/main/java/org/jboss/as/quickstarts/kitchensink/model/Member.java
+++ b/kitchensink-spring-boot/src/main/java/org/jboss/as/quickstarts/kitchensink/model/Member.java
@@ -1,0 +1,34 @@
+package org.jboss.as.quickstarts.kitchensink.model;
+
+import jakarta.persistence.*;
+import jakarta.validation.constraints.*;
+import lombok.*;
+
+import java.io.Serializable;
+
+@Entity
+@Table(name = "Member", uniqueConstraints = @UniqueConstraint(columnNames = "email"))
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class Member implements Serializable {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @NotNull
+    @Size(min = 1, max = 25)
+    @Pattern(regexp = "[^0-9]*", message = "Must not contain numbers")
+    private String name;
+
+    @NotNull
+    @NotEmpty
+    @Email
+    private String email;
+
+    @NotNull
+    @Size(min = 10, max = 12)
+    @Digits(fraction = 0, integer = 12)
+    @Column(name = "phone_number")
+    private String phoneNumber;
+}

--- a/kitchensink-spring-boot/src/main/java/org/jboss/as/quickstarts/kitchensink/repository/MemberRepository.java
+++ b/kitchensink-spring-boot/src/main/java/org/jboss/as/quickstarts/kitchensink/repository/MemberRepository.java
@@ -1,0 +1,13 @@
+package org.jboss.as.quickstarts.kitchensink.repository;
+
+import org.jboss.as.quickstarts.kitchensink.model.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface MemberRepository extends JpaRepository<Member, Long> {
+    Optional<Member> findByEmail(String email);
+    boolean existsByEmail(String email);
+    List<Member> findAllByOrderByNameAsc();
+}

--- a/kitchensink-spring-boot/src/main/java/org/jboss/as/quickstarts/kitchensink/service/MemberService.java
+++ b/kitchensink-spring-boot/src/main/java/org/jboss/as/quickstarts/kitchensink/service/MemberService.java
@@ -1,0 +1,33 @@
+package org.jboss.as.quickstarts.kitchensink.service;
+
+import lombok.RequiredArgsConstructor;
+import org.jboss.as.quickstarts.kitchensink.model.Member;
+import org.jboss.as.quickstarts.kitchensink.repository.MemberRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Optional;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class MemberService {
+    private final MemberRepository repository;
+
+    public List<Member> listAllOrderedByName() {
+        return repository.findAllByOrderByNameAsc();
+    }
+
+    public Optional<Member> findById(Long id) {
+        return repository.findById(id);
+    }
+
+    public boolean emailAlreadyExists(String email) {
+        return repository.existsByEmail(email);
+    }
+
+    public Member register(Member member) {
+        return repository.save(member);
+    }
+}

--- a/kitchensink-spring-boot/src/main/java/org/jboss/as/quickstarts/kitchensink/web/GlobalExceptionHandler.java
+++ b/kitchensink-spring-boot/src/main/java/org/jboss/as/quickstarts/kitchensink/web/GlobalExceptionHandler.java
@@ -1,0 +1,45 @@
+package org.jboss.as.quickstarts.kitchensink.web;
+
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.context.request.WebRequest;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@ControllerAdvice
+public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
+
+    @Override
+    protected ResponseEntity<Object> handleMethodArgumentNotValid(MethodArgumentNotValidException ex,
+                                                                  HttpHeaders headers,
+                                                                  HttpStatus status,
+                                                                  WebRequest request) {
+        Map<String, String> errors = new HashMap<>();
+        for (FieldError fieldError : ex.getBindingResult().getFieldErrors()) {
+            errors.put(fieldError.getField(), fieldError.getDefaultMessage());
+        }
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(errors);
+    }
+
+    @ExceptionHandler(DataIntegrityViolationException.class)
+    public ResponseEntity<?> handleDataIntegrity(DataIntegrityViolationException ex) {
+        Map<String, String> conflict = new HashMap<>();
+        conflict.put("email", "Email taken");
+        return ResponseEntity.status(HttpStatus.CONFLICT).body(conflict);
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<?> handleGeneric(Exception ex) {
+        Map<String, String> error = new HashMap<>();
+        error.put("error", ex.getMessage());
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(error);
+    }
+}

--- a/kitchensink-spring-boot/src/main/java/org/jboss/as/quickstarts/kitchensink/web/MemberController.java
+++ b/kitchensink-spring-boot/src/main/java/org/jboss/as/quickstarts/kitchensink/web/MemberController.java
@@ -1,0 +1,49 @@
+package org.jboss.as.quickstarts.kitchensink.web;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.jboss.as.quickstarts.kitchensink.model.Member;
+import org.jboss.as.quickstarts.kitchensink.service.MemberService;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.BindingResult;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@RestController
+@RequestMapping("/rest/members")
+@RequiredArgsConstructor
+public class MemberController {
+    private final MemberService service;
+
+    @GetMapping
+    public List<Member> listAllMembers() {
+        return service.listAllOrderedByName();
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<Member> lookupMemberById(@PathVariable Long id) {
+        return service.findById(id)
+                .map(ResponseEntity::ok)
+                .orElseGet(() -> ResponseEntity.status(HttpStatus.NOT_FOUND).build());
+    }
+
+    @PostMapping
+    public ResponseEntity<?> createMember(@Valid @RequestBody Member member, BindingResult bindingResult) {
+        if (bindingResult.hasErrors()) {
+            Map<String, String> errors = new HashMap<>();
+            bindingResult.getFieldErrors().forEach(e -> errors.put(e.getField(), e.getDefaultMessage()));
+            return ResponseEntity.badRequest().body(errors);
+        }
+        if (service.emailAlreadyExists(member.getEmail())) {
+            Map<String, String> conflict = new HashMap<>();
+            conflict.put("email", "Email taken");
+            return ResponseEntity.status(HttpStatus.CONFLICT).body(conflict);
+        }
+        service.register(member);
+        return ResponseEntity.ok().build();
+    }
+}

--- a/kitchensink-spring-boot/src/main/resources/application.yml
+++ b/kitchensink-spring-boot/src/main/resources/application.yml
@@ -1,0 +1,23 @@
+spring:
+  application:
+    name: kitchensink
+  datasource:
+    url: jdbc:h2:mem:kitchensink;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
+    driver-class-name: org.h2.Driver
+    username: sa
+    password: 
+  jpa:
+    hibernate:
+      ddl-auto: update
+    open-in-view: false
+    properties:
+      hibernate:
+        format_sql: true
+        jdbc:
+          time_zone: UTC
+  h2:
+    console:
+      enabled: true
+
+server:
+  port: 8080

--- a/kitchensink-spring-boot/src/main/resources/data.sql
+++ b/kitchensink-spring-boot/src/main/resources/data.sql
@@ -1,0 +1,1 @@
+INSERT INTO Member (id, name, email, phone_number) VALUES (0, 'John Smith', 'john.smith@mailinator.com', '2125551212');

--- a/kitchensink-spring-boot/src/test/java/org/jboss/as/quickstarts/kitchensink/MemberControllerIT.java
+++ b/kitchensink-spring-boot/src/test/java/org/jboss/as/quickstarts/kitchensink/MemberControllerIT.java
@@ -1,0 +1,58 @@
+package org.jboss.as.quickstarts.kitchensink;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.jboss.as.quickstarts.kitchensink.model.Member;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class MemberControllerIT {
+
+    @Autowired
+    MockMvc mockMvc;
+
+    @Autowired
+    ObjectMapper objectMapper;
+
+    @Test
+    void listAndGetAndCreateFlow() throws Exception {
+        // list
+        mockMvc.perform(get("/rest/members"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON));
+
+        // create valid
+        Member m = new Member(null, "Alice", "alice@example.com", "1234567890");
+        mockMvc.perform(post("/rest/members")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(m)))
+                .andExpect(status().isOk());
+
+        // duplicate email
+        mockMvc.perform(post("/rest/members")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(m)))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.email").value("Email taken"));
+    }
+
+    @Test
+    void validationErrors() throws Exception {
+        Member bad = new Member(null, "Bob1", "not-an-email", "12");
+        mockMvc.perform(post("/rest/members")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(bad)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.name").exists())
+                .andExpect(jsonPath("$.email").exists())
+                .andExpect(jsonPath("$.phoneNumber").exists());
+    }
+}


### PR DESCRIPTION
This is a Droid-assisted PR.

Summary
- Adds a fresh Spring Boot 3.3.2 (Java 21) application under kitchensink-spring-boot/
- Preserves Kitchensink functionality and API behavior using Spring conventions

Key changes
- Domain Model: Member entity (JPA + Lombok + Bean Validation, unique email; phone_number column)
- Data Access: Spring Data JPA MemberRepository (findAllByOrderByNameAsc, existsByEmail, findByEmail)
- Business Logic: MemberService with @Transactional
- REST API: MemberController at /rest/members
  - GET /rest/members → list ordered by name
  - GET /rest/members/{id} → 200 OK or 404 Not Found
  - POST /rest/members → 200 OK on success; 400 with {field: message} for validation; 409 with {"email":"Email taken"} on duplicate
- Exception Handling: Global @ControllerAdvice for validation (400), data integrity (409), generic (400)
- Configuration: H2 in-memory, JPA ddl-auto=update, open-in-view=false, H2 console enabled
- Seed Data: data.sql with initial Member row
- Tests: MockMvc integration tests for happy path, validation errors, and duplicate email

Paths added
- kitchensink-spring-boot/pom.xml
- kitchensink-spring-boot/.gitignore
- kitchensink-spring-boot/src/main/java/org/jboss/as/quickstarts/kitchensink/KitchensinkApplication.java
- kitchensink-spring-boot/src/main/java/org/jboss/as/quickstarts/kitchensink/model/Member.java
- kitchensink-spring-boot/src/main/java/org/jboss/as/quickstarts/kitchensink/repository/MemberRepository.java
- kitchensink-spring-boot/src/main/java/org/jboss/as/quickstarts/kitchensink/service/MemberService.java
- kitchensink-spring-boot/src/main/java/org/jboss/as/quickstarts/kitchensink/web/MemberController.java
- kitchensink-spring-boot/src/main/java/org/jboss/as/quickstarts/kitchensink/web/GlobalExceptionHandler.java
- kitchensink-spring-boot/src/main/resources/application.yml
- kitchensink-spring-boot/src/main/resources/data.sql
- kitchensink-spring-boot/src/test/java/org/jboss/as/quickstarts/kitchensink/MemberControllerIT.java

How to build/test locally
- Requires Maven. Example via Docker (no local install):
  docker run --rm -v "$PWD/kitchensink-spring-boot":/app -w /app maven:3.9-eclipse-temurin-21 mvn -q -DskipTests=false clean verify

Notes
- API remains under /rest/members to match legacy JAX-RS endpoints
- Response semantics preserved: 200 on create, 400 validation map, 409 email conflict

Linear: PRO-339

---
**Factory Session:** https://app.factory.ai/sessions/xewbEiPN8FIofdYqSVSp (created by factory-shiv)