### PR TITLE
feat: Spring Boot migration scaffolding for kitchensink (PRO-401) [Droid-assisted]

### DIFF
--- a/kitchensink-springboot/.gitignore
+++ b/kitchensink-springboot/.gitignore
@@ -1,0 +1,5 @@
+target/
+.idea/
+.classpath
+.project
+.settings/

--- a/kitchensink-springboot/pom.xml
+++ b/kitchensink-springboot/pom.xml
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>com.factory</groupId>
+    <artifactId>kitchensink-springboot</artifactId>
+    <version>0.1.0-SNAPSHOT</version>
+    <name>kitchensink-springboot</name>
+    <description>Spring Boot migration of JBoss kitchensink (PRO-401)</description>
+    <properties>
+        <java.version>21</java.version>
+        <spring-boot.version>3.3.4</spring-boot.version>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-dependencies</artifactId>
+                <version>${spring-boot.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-validation</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-data-jpa</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.11.0</version>
+                <configuration>
+                    <release>${java.version}</release>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/kitchensink-springboot/src/main/java/com/factory/kitchensink/KitchensinkApplication.java
+++ b/kitchensink-springboot/src/main/java/com/factory/kitchensink/KitchensinkApplication.java
@@ -1,0 +1,11 @@
+package com.factory.kitchensink;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class KitchensinkApplication {
+    public static void main(String[] args) {
+        SpringApplication.run(KitchensinkApplication.class, args);
+    }
+}

--- a/kitchensink-springboot/src/main/java/com/factory/kitchensink/data/MemberRepository.java
+++ b/kitchensink-springboot/src/main/java/com/factory/kitchensink/data/MemberRepository.java
@@ -1,0 +1,10 @@
+package com.factory.kitchensink.data;
+
+import com.factory.kitchensink.model.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface MemberRepository extends JpaRepository<Member, Long> {
+    Optional<Member> findByEmail(String email);
+}

--- a/kitchensink-springboot/src/main/java/com/factory/kitchensink/model/Member.java
+++ b/kitchensink-springboot/src/main/java/com/factory/kitchensink/model/Member.java
@@ -1,0 +1,37 @@
+package com.factory.kitchensink.model;
+
+import jakarta.persistence.*;
+import jakarta.validation.constraints.*;
+
+@Entity
+@Table(name = "member", uniqueConstraints = @UniqueConstraint(columnNames = "email"))
+public class Member {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @NotNull
+    @Size(min = 1, max = 25)
+    @Pattern(regexp = "[^0-9]*", message = "Must not contain numbers")
+    private String name;
+
+    @NotNull
+    @NotEmpty
+    @Email
+    private String email;
+
+    @NotNull
+    @Size(min = 10, max = 12)
+    @Digits(fraction = 0, integer = 12)
+    @Column(name = "phone_number")
+    private String phoneNumber;
+
+    public Long getId() { return id; }
+    public void setId(Long id) { this.id = id; }
+    public String getName() { return name; }
+    public void setName(String name) { this.name = name; }
+    public String getEmail() { return email; }
+    public void setEmail(String email) { this.email = email; }
+    public String getPhoneNumber() { return phoneNumber; }
+    public void setPhoneNumber(String phoneNumber) { this.phoneNumber = phoneNumber; }
+}

--- a/kitchensink-springboot/src/main/java/com/factory/kitchensink/service/MemberService.java
+++ b/kitchensink-springboot/src/main/java/com/factory/kitchensink/service/MemberService.java
@@ -1,0 +1,26 @@
+package com.factory.kitchensink.service;
+
+import com.factory.kitchensink.data.MemberRepository;
+import com.factory.kitchensink.model.Member;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class MemberService {
+    private final MemberRepository repository;
+
+    public MemberService(MemberRepository repository) {
+        this.repository = repository;
+    }
+
+    @Transactional
+    public Member register(Member member) {
+        try {
+            return repository.save(member);
+        } catch (DataIntegrityViolationException e) {
+            // rethrow to be mapped by exception handler as 409
+            throw e;
+        }
+    }
+}

--- a/kitchensink-springboot/src/main/java/com/factory/kitchensink/web/GlobalExceptionHandler.java
+++ b/kitchensink-springboot/src/main/java/com/factory/kitchensink/web/GlobalExceptionHandler.java
@@ -1,0 +1,39 @@
+package com.factory.kitchensink.web;
+
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@ControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<Map<String, String>> handleValidation(MethodArgumentNotValidException ex) {
+        Map<String, String> errors = new HashMap<>();
+        for (FieldError fe : ex.getBindingResult().getFieldErrors()) {
+            errors.put(fe.getField(), fe.getDefaultMessage());
+        }
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(errors);
+    }
+
+    @ExceptionHandler(DataIntegrityViolationException.class)
+    public ResponseEntity<Map<String, String>> handleUniqueConstraint(DataIntegrityViolationException ex) {
+        Map<String, String> error = new HashMap<>();
+        error.put("email", "Email taken");
+        return ResponseEntity.status(HttpStatus.CONFLICT).body(error);
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<Map<String, String>> handleGeneric(Exception ex) {
+        Map<String, String> error = new HashMap<>();
+        error.put("error", ex.getMessage());
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(error);
+    }
+}

--- a/kitchensink-springboot/src/main/java/com/factory/kitchensink/web/MemberController.java
+++ b/kitchensink-springboot/src/main/java/com/factory/kitchensink/web/MemberController.java
@@ -1,0 +1,44 @@
+package com.factory.kitchensink.web;
+
+import com.factory.kitchensink.data.MemberRepository;
+import com.factory.kitchensink.model.Member;
+import com.factory.kitchensink.service.MemberService;
+import jakarta.validation.Valid;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping(path = "/rest/members", produces = MediaType.APPLICATION_JSON_VALUE)
+public class MemberController {
+    private final MemberRepository repository;
+    private final MemberService service;
+
+    public MemberController(MemberRepository repository, MemberService service) {
+        this.repository = repository;
+        this.service = service;
+    }
+
+    @GetMapping
+    public List<Member> listAllMembers() {
+        return repository.findAll().stream()
+                .sorted((a,b) -> a.getName().compareToIgnoreCase(b.getName()))
+                .toList();
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<Member> lookupMemberById(@PathVariable Long id) {
+        return repository.findById(id)
+                .map(ResponseEntity::ok)
+                .orElseGet(() -> ResponseEntity.status(HttpStatus.NOT_FOUND).build());
+    }
+
+    @PostMapping(consumes = MediaType.APPLICATION_JSON_VALUE)
+    public ResponseEntity<?> createMember(@Valid @RequestBody Member member) {
+        service.register(member);
+        return ResponseEntity.ok().build();
+    }
+}

--- a/kitchensink-springboot/src/main/resources/application.properties
+++ b/kitchensink-springboot/src/main/resources/application.properties
@@ -1,0 +1,19 @@
+# Spring Boot configuration for kitchensink migration (PRO-401)
+spring.application.name=kitchensink-springboot
+
+server.port=8080
+
+# H2 in-memory DB for dev
+spring.datasource.url=jdbc:h2:mem:kitchensink;DB_CLOSE_DELAY=-1;MODE=LEGACY
+spring.datasource.driverClassName=org.h2.Driver
+spring.datasource.username=sa
+spring.datasource.password=
+
+# JPA / Hibernate
+spring.jpa.hibernate.ddl-auto=update
+spring.jpa.show-sql=true
+spring.jpa.properties.hibernate.format_sql=true
+
+# H2 console (optional)
+spring.h2.console.enabled=true
+spring.h2.console.path=/h2-console

--- a/kitchensink-springboot/src/main/resources/data.sql
+++ b/kitchensink-springboot/src/main/resources/data.sql
@@ -1,0 +1,2 @@
+INSERT INTO member (id, name, email, phone_number) VALUES
+  (1, 'John Smith', 'john.smith@example.com', '1234567890');


### PR DESCRIPTION
This PR introduces a new Spring Boot 3 app for the kitchensink migration (PRO-401). Highlights: Boot 3.3 app in kitchensink-springboot; Ported Member model with Spring Data JPA; Service + REST controller under /rest/members; Bean Validation + global exception handling; H2 dev config and seed data. Built locally with mvn package.